### PR TITLE
Remove z-index from ProfilePage CSS

### DIFF
--- a/src/components/ProfilePage/ProfilePage.css
+++ b/src/components/ProfilePage/ProfilePage.css
@@ -25,7 +25,6 @@
     justify-content: space-between;
     align-items: center;
     height: 120px;
-    z-index: 500;
 }
 
 .profile-details,


### PR DESCRIPTION
## Describe your changes

The unnecessary CSS property z-index has been removed from the ProfilePage component. This change is made to streamline the CSS and potentially avoid any future z-index related issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What kind of feedback do you need?

Need a quick look 

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have recommended where to start and how to proceed with the review
- [x] I have done a git pull from DEV to ensure this PR is up to date