### PR TITLE
Lindi/upgrade for state country names render

### DIFF
--- a/src/api/delete-experience.js
+++ b/src/api/delete-experience.js
@@ -1,5 +1,5 @@
 async function deleteExperience(experienceId) {
-    const url = `${import.meta.env.VITE_API_URL}/experience/${experienceId}`;
+    const url = `${import.meta.env.VITE_API_URL}/experience/${experienceId}/`;
 
     const token =window.localStorage.getItem("token");
 

--- a/src/api/delete-user.js
+++ b/src/api/delete-user.js
@@ -1,5 +1,5 @@
 async function deleteUser(username) {
-    const url = `${import.meta.env.VITE_API_URL}/users/${username}`;
+    const url = `${import.meta.env.VITE_API_URL}/users/${username}/`;
 
     const token = window.localStorage.getItem('token');
 

--- a/src/api/get-experience.js
+++ b/src/api/get-experience.js
@@ -1,5 +1,5 @@
 async function getExperience(experienceId) {
-    const url = `${import.meta.env.VITE_API_URL}/experience/${experienceId}`;
+    const url = `${import.meta.env.VITE_API_URL}/experience/${experienceId}/`;
     const response = await fetch(url, {method: 'GET'});
 
     if(!response.ok){

--- a/src/api/get-experiences.js
+++ b/src/api/get-experiences.js
@@ -1,5 +1,5 @@
 async function getExperiences(profileId){
-    const url=`${import.meta.env.VITE_API_URL}/profile/${profileId}/experiences`;
+    const url=`${import.meta.env.VITE_API_URL}/profile/${profileId}/experiences/`;
     // to test in local: comment line above and uncomment line below (also check url in line below matches your local backend url)
     // const url=`http://127.0.0.1:8000/profiles`;
     

--- a/src/api/get-profile.js
+++ b/src/api/get-profile.js
@@ -1,6 +1,6 @@
 async function getProfile(profileId){
 
-    const url = `${import.meta.env.VITE_API_URL}/profile/${profileId}`;
+    const url = `${import.meta.env.VITE_API_URL}/profile/${profileId}/`;
    
 
     const response = await fetch (url,{method:"GET"});

--- a/src/api/get-profiles.js
+++ b/src/api/get-profiles.js
@@ -1,5 +1,5 @@
 async function getProfiles(){
-const url=`${import.meta.env.VITE_API_URL}/profiles`;
+const url=`${import.meta.env.VITE_API_URL}/profiles/`;
 
 const response=await fetch(url,{method:"GET"});
 

--- a/src/api/get-user.js
+++ b/src/api/get-user.js
@@ -1,5 +1,5 @@
 async function getUser(userId) {
-    const url = `${import.meta.env.VITE_API_URL}/users/${userId}`;
+    const url = `${import.meta.env.VITE_API_URL}/users/${userId}/`;
 
     const token = window.localStorage.getItem('token');
 

--- a/src/api/get-users.js
+++ b/src/api/get-users.js
@@ -1,5 +1,5 @@
 async function getUsers(){
-    const url=`${import.meta.env.VITE_API_URL}/users`;
+    const url=`${import.meta.env.VITE_API_URL}/users/`;
 
 
     const token = window.localStorage.getItem('token');

--- a/src/api/put-experience.js
+++ b/src/api/put-experience.js
@@ -6,7 +6,7 @@ async function putExperience(
     is_present_experience,
     start_date, 
     end_date, experienceId) {
-    const url = `${import.meta.env.VITE_API_URL}/experience/${experienceId}`;
+    const url = `${import.meta.env.VITE_API_URL}/experience/${experienceId}/`;
     const token =window.localStorage.getItem("token");
 
      const response = await fetch(url, {

--- a/src/components/Forms/SelectOptions/IndustriesMultiselectDropdown.jsx
+++ b/src/components/Forms/SelectOptions/IndustriesMultiselectDropdown.jsx
@@ -7,7 +7,6 @@ function useIndusty(setIndustryOptions) {
     useEffect(() => {
         getIndustries().then(data => {
             setIndustryOptions(data.industryOptions);
-            console.log(data.industryOptions);
         }).catch(error => {
             console.error('Error fetching industy:', error);
         });

--- a/src/components/Forms/SelectOptions/LocationDropdowns.jsx
+++ b/src/components/Forms/SelectOptions/LocationDropdowns.jsx
@@ -21,10 +21,10 @@ function LocationDropdowns({setCountryIso2, setStateIso2, setSelectedCityId, cou
                 { countryIso2 
                     && <StateSelect countryIso2={countryIso2} setStateIso2={setStateIso2}/>}
             </div>
-            <div>
+            {/* <div>
                 { stateIso2 
                     && <CitySelect countryIso2={countryIso2} stateIso2={stateIso2} setSelectedCityId={setSelectedCityId}/>}
-            </div>
+            </div> */}
         </div>
     );
 }

--- a/src/components/Forms/SelectOptions/TagsMultiselectDropdown.jsx
+++ b/src/components/Forms/SelectOptions/TagsMultiselectDropdown.jsx
@@ -6,7 +6,6 @@ function useTags(setTagOptions) {
     useEffect(() => {
         getTags().then(data => {
             setTagOptions(data.tagOptions);
-            console.log(data.tagOptions);
         }).catch(error => {
             console.error('Error fetching tags:', error);
         });

--- a/src/components/ProfileCards/ProfileCard.jsx
+++ b/src/components/ProfileCards/ProfileCard.jsx
@@ -23,8 +23,9 @@ function ProfileCard({ profile }) {
   const { user, isLoading, error } = useUser(profile.owner);
   const [username, setUsername] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const [countryName, setCountryName] = useState("");
+
   const [stateName, setStateName] = useState("");
+  const [countryName, setCountryName] = useState("");
   const [areaName, setAreaName] = useState("");
 
   const toggleDropdown = () => {
@@ -34,32 +35,40 @@ function ProfileCard({ profile }) {
   {
     /* Retrieval of user first name and last name is still not working  */
   }
-console.log("profile.country", profile.country);
   useEffect(() => {
-    if (profile.country) {
-      getCountries().then((data) => {
-        const country = data.countriesData.find(
-          (country) => country.iso2 === profile.country
-        );
-        setCountryName(country.name);
-      });
+    if (profile.owner === user.id) {
+      if (!profile.country || profile.country === "") {
+        setCountryName("");
+      } else
+      if (profile.country) {
+        getCountries().then((data) => {
+          const country = data.countriesData.find(
+            (country) => country.iso2 === profile.country
+          );
+          console.log("country in use effect:", country);
+          setCountryName(country.name);
+        });
+      }
     }
-  }, [profile.country]);
-
-  const countryIso2 = profile.country;
-
+  }, [profile.country, profile.owner, user.id, countryName]);
+  console.log("profile:",profile.owner, "profile.country:",profile.country, "countryName:", countryName);
+  
+  let countryIso2 = profile.country;
+  
   useEffect(() => {
-    if (profile.state) {
-      getStates(countryIso2).then((data) => {
-        const state = data.statesData.find(
-          (state) => state.iso2 === profile.state
-        );
-        setStateName(state.name);
-      });
-    }
-  }, [profile.state]);
-
-  const stateIso2 = profile.state;
+      if (profile.owner === user.id) {
+        if (!profile.state || profile.state === "") {
+          setStateName("");
+         } else if
+          (profile.state || profile.country) {
+            getStates(countryIso2).then((data) => {
+              const state = data.statesData.find((state) => state.iso2 === profile.state);
+              setStateName(state.name);
+            });
+          }
+      }
+  }, [profile.state, profile.owner, user.id, countryIso2]);
+  console.log("profile:",profile.owner, "profile.state:",profile.state ,"stateName:", stateName);
 
   useEffect(() => {
     if (!isLoading && !error && user) {

--- a/src/components/ProfileCards/ProfileCard.jsx
+++ b/src/components/ProfileCards/ProfileCard.jsx
@@ -18,8 +18,6 @@ import getCountries from "../../api/get-countries";
 import getStates from "../../api/get-states";
 
 function ProfileCard({ profile }) {
-  // console.log("profile in profile card:", profile);
-
   const { user, isLoading, error } = useUser(profile.owner);
   const [username, setUsername] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -45,13 +43,11 @@ function ProfileCard({ profile }) {
           const country = data.countriesData.find(
             (country) => country.iso2 === profile.country
           );
-          console.log("country in use effect:", country);
           setCountryName(country.name);
         });
       }
     }
   }, [profile.country, profile.owner, user.id, countryName]);
-  console.log("profile:",profile.owner, "profile.country:",profile.country, "countryName:", countryName);
   
   let countryIso2 = profile.country;
   
@@ -68,7 +64,6 @@ function ProfileCard({ profile }) {
           }
       }
   }, [profile.state, profile.owner, user.id, countryIso2]);
-  console.log("profile:",profile.owner, "profile.state:",profile.state ,"stateName:", stateName);
 
   useEffect(() => {
     if (!isLoading && !error && user) {

--- a/src/components/ProfileCards/ProfileCard.jsx
+++ b/src/components/ProfileCards/ProfileCard.jsx
@@ -14,13 +14,18 @@ import { CgProfile } from "react-icons/cg";
 
 import { Link } from "react-router-dom";
 import React, { useEffect, useState } from "react";
+import getCountries from "../../api/get-countries";
+import getStates from "../../api/get-states";
 
 function ProfileCard({ profile }) {
-  console.log("profile in profile card:", profile);
+  // console.log("profile in profile card:", profile);
 
   const { user, isLoading, error } = useUser(profile.owner);
   const [username, setUsername] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [countryName, setCountryName] = useState("");
+  const [stateName, setStateName] = useState("");
+  const [areaName, setAreaName] = useState("");
 
   const toggleDropdown = () => {
     setDropdownOpen(!dropdownOpen);
@@ -29,6 +34,33 @@ function ProfileCard({ profile }) {
   {
     /* Retrieval of user first name and last name is still not working  */
   }
+console.log("profile.country", profile.country);
+  useEffect(() => {
+    if (profile.country) {
+      getCountries().then((data) => {
+        const country = data.countriesData.find(
+          (country) => country.iso2 === profile.country
+        );
+        setCountryName(country.name);
+      });
+    }
+  }, [profile.country]);
+
+  const countryIso2 = profile.country;
+
+  useEffect(() => {
+    if (profile.state) {
+      getStates(countryIso2).then((data) => {
+        const state = data.statesData.find(
+          (state) => state.iso2 === profile.state
+        );
+        setStateName(state.name);
+      });
+    }
+  }, [profile.state]);
+
+  const stateIso2 = profile.state;
+
   useEffect(() => {
     if (!isLoading && !error && user) {
       if (profile.owner === user.id) {
@@ -72,7 +104,10 @@ function ProfileCard({ profile }) {
           <div>
             {/*I am supposed to be retrieveing username from user object here, but havent been successful so far*/}
             <h4>{isLoading ? "Loading name..." : username}</h4>
-            <p>{profile.location}</p>
+            {/* <p>{!(areaName) ? ("") : (areaName)}</p> */}
+            <p>{!(stateName) ? ("") : (stateName)}</p>
+            <p>{!(countryName) ? ("") : (countryName)}</p>
+
           </div>
 
           <div className="profile--card-header-share">

--- a/src/components/ProfileCards/ProfileCards.jsx
+++ b/src/components/ProfileCards/ProfileCards.jsx
@@ -55,7 +55,7 @@ function ProfileCards({ profiles }) {
     <>
       <div className="profile-cards-container">
         {currentProfiles.map((profile, index) => (
-          <ProfileCard key={index} profile={profile} />
+          <ProfileCard key={index} profile={profile}/>
         ))}
       </div>
       <div className="paginate-section">

--- a/src/components/ProfilePage/ProfilePageRender.jsx
+++ b/src/components/ProfilePage/ProfilePageRender.jsx
@@ -2,7 +2,7 @@ import useUser from "../../hooks/use-user.js";
 import useProfile from "../../hooks/use-profile.js";
 import { useParams, Link } from "react-router-dom";
 import { useState, useEffect } from "react";
-import { FaPlus } from "react-icons/fa6";
+import { FaHouseMedicalCircleExclamation, FaPlus } from "react-icons/fa6";
 import ExperienceCard from "../ExperienceCard/ExperienceCard.jsx";
 import CreateExperienceForm from "../Forms/CreateExperienceForm.jsx";
 import "../ProfilePage/ProfilePage.css";
@@ -18,6 +18,10 @@ import {
 } from "react-icons/bs";
 import { IoIosCloseCircle } from "react-icons/io";
 import useExperiences from "../../hooks/use-experiences.js";
+import getCountries from "../../api/get-countries.js";
+import getStates from "../../api/get-states.js";
+import getCities from "../../api/get-cities.js";
+import { MdOutlineExpandCircleDown } from "react-icons/md";
 
 function ProfilePageDetails() {
   const { id } = useParams();
@@ -34,11 +38,53 @@ function ProfilePageDetails() {
   const userData = useUser(profile.owner);
   const tags = profile.tags;
   const { auth, setAuth } = useAuth();
+  const [countryName, setCountryName] = useState("");
+  const [stateName, setStateName] = useState("");
+  const [areaName, setAreaName] = useState("");
+  console.log ( "areaName:", areaName);
 
   const { experiences, isLoading, error } = useExperiences(id);
   const [experiencePopUp, setExperiencePopUp] = useState(false);
 
   console.log("profile.owner:", profile.owner);
+
+  useEffect(() => {
+    if (profile.country) {
+      getCountries().then((data) => {
+        const country = data.countriesData.find(
+          (country) => country.iso2 === profile.country
+        );
+        setCountryName(country.name);
+      });
+    }
+  }, [profile.country]);
+
+  const countryIso2 = profile.country;
+
+  useEffect(() => {
+    if (profile.state) {
+      getStates(countryIso2).then((data) => {
+        const state = data.statesData.find(
+          (state) => state.iso2 === profile.state
+        );
+        setStateName(state.name);
+      });
+    }
+  }, [profile.state]);
+
+  const stateIso2 = profile.state;
+
+  // TO BE IMPLEMENTED AND DEBUGGED WHEN AREA API IS AVAILABLE
+  // useEffect(() => {
+  //   if (profile.area) {
+  //     getCities(countryIso2, stateIso2).then((data) => {
+  //       const city = data.citiesData.find(
+  //         (city) => city.id === profile.area
+  //       );
+  //       setAreaName(city.name);
+  //     });
+  //   }
+  // }, [profile.area]);
 
   useEffect(() => {
     // Check if profile data is available and not loading
@@ -70,6 +116,8 @@ function ProfilePageDetails() {
   console.log("profile data:", profile);
   console.log("user_id:", user.id);
 
+
+  console.log("countryName:", countryName);
   return (
     <section className="profile-page-body main-container">
       <div className="profile-page-container">
@@ -86,8 +134,9 @@ function ProfilePageDetails() {
         <div className="profile-details">
           <h3>{username}</h3>
           <h3>Username: {user.username}</h3>
-
-          <p>{profile.location}</p>
+          <p>{!(areaName) ? ("") : (areaName)}</p>
+          <p>{!(stateName) ? ("") : (stateName)}</p>
+          <p>{!(countryName) ? ("") : (countryName)}</p>
           <div className="profile-page-render--card-body">
             <div className="profile-Card-Body">
               {profile.is_open_to_mentor ? (

--- a/src/components/ProfilePage/ProfilePageRender.jsx
+++ b/src/components/ProfilePage/ProfilePageRender.jsx
@@ -41,12 +41,9 @@ function ProfilePageDetails() {
   const [countryName, setCountryName] = useState("");
   const [stateName, setStateName] = useState("");
   const [areaName, setAreaName] = useState("");
-  console.log ( "areaName:", areaName);
 
   const { experiences, isLoading, error } = useExperiences(id);
   const [experiencePopUp, setExperiencePopUp] = useState(false);
-
-  console.log("profile.owner:", profile.owner);
 
   useEffect(() => {
     if (profile.country) {
@@ -91,10 +88,8 @@ function ProfilePageDetails() {
     if (userData.user) {
       try {
         setUser(userData.user); // Set user data
-        console.log("userData:", userData);
         setUsername(`${userData.user.first_name} ${userData.user.last_name}`); // Update username based on user data
         setUserLoading(false);
-        console.log("username:", username);
       } catch (error) {
         setUserError(error);
         setUserLoading(false);
@@ -112,12 +107,7 @@ function ProfilePageDetails() {
   if (userError) {
     return <p>Sorry we cant load the user information!</p>;
   }
-  console.log("tags:", profile.tags.length);
-  console.log("profile data:", profile);
-  console.log("user_id:", user.id);
 
-
-  console.log("countryName:", countryName);
   return (
     <section className="profile-page-body main-container">
       <div className="profile-page-container">

--- a/src/components/ProfilePage/ProfilePageRender.jsx
+++ b/src/components/ProfilePage/ProfilePageRender.jsx
@@ -195,7 +195,7 @@ function ProfilePageDetails() {
           <div>
             {profile.industries.length === 0 ? null : (
               <div className="industry-tags">
-                <h3>Industry Tags:</h3>
+                <h3>Industry Categories:</h3>
                 <ul>
                   {profile.industries.map((industry, index) => (
                     <li key={index}>{industry}</li>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -50,7 +50,6 @@ function filterProfiles(
     }
   
     return profiles.filter((profile) => {
-      console.log("filterArea, profile.area", filterArea, profile.area);
       // true if the profile matches all the filters
       return doesProfileMatchMultiSelect(profile.tags, filterTags) &&
       doesProfileMatchMultiSelect(profile.industries, filterIndustries) &&
@@ -100,17 +99,6 @@ function HomePage() {
     stateIso2,
     area
   );
-
-  // console.log("Profiles:", profiles);
-  console.log("Toggles outside:", toggles);
-  console.log("isOpenToMentorToggle:", isOpenToMentorToggle);
-  console.log("isSeekingMentorhip:",isSeekingMentorshipToggle);
-  console.log("SelectedTags:", selectedTags);
-  console.log("FilteredProfiles:", filteredProfiles);
-  console.log("SelectedIndustries:", selectedIndustries);
-  console.log("StateIso2:", stateIso2);
-  console.log("CountryIso2:", countryIso2); 
-  console.log("Area:", area);
 
   return (
     <div className="main-container">


### PR DESCRIPTION
## Describe your changes

**This upgrade will only work effectively when backend 'main' has area / state / country feilds in the profile model**
Tested with backend as current DEV branch

### Rendering state names and country names:

#### Profile Cards:
<img width="770" alt="image" src="https://github.com/SheCodesAus/2024_a_dynamic_array_frontend/assets/16198398/e278ddbd-b742-49b6-951a-f9d8f6ed3a38">

#### Profile Page:
<img width="339" alt="image" src="https://github.com/SheCodesAus/2024_a_dynamic_array_frontend/assets/16198398/efb8ff1d-12e0-49c2-ab74-692c53012a89">

For the sake of a neat package, I have also removed the cities (or areas) as selectable input fields in the create profile and the filters, as the 'areas' API needs work, and the current 'cities' API is too granular according to the client's requirements.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## What kind of feedback do you need?

This has been tested - see results above.
This PR should not be merged until deployed profile model incudes area, state and country feilds.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have recommended where to start and how to proceed with the review
- [x] I have done a git pull from DEV to ensure this PR is up to date